### PR TITLE
language-model: Rework into "cursors" model

### DIFF
--- a/ggml-gobject/ggml-cached-model.h
+++ b/ggml-gobject/ggml-cached-model.h
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#pragma once
+
 #include <gio/gio.h>
 #include <glib-object.h>
 

--- a/ggml-gobject/ggml-gobject.h
+++ b/ggml-gobject/ggml-gobject.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <ggml-gobject/ggml-cached-model.h>
 #include <ggml-gobject/ggml-compute-graph.h>
 #include <ggml-gobject/ggml-context.h>
 #include <ggml-gobject/ggml-gpt.h>
@@ -30,6 +31,7 @@
 #include <ggml-gobject/ggml-model-desc.h>
 #include <ggml-gobject/ggml-model.h>
 #include <ggml-gobject/ggml-ops.h>
+#include <ggml-gobject/ggml-quantize.h>
 #include <ggml-gobject/ggml-tensor.h>
 #include <ggml-gobject/ggml-token-dictionary.h>
 #include <ggml-gobject/ggml-types.h>

--- a/ggml-gobject/ggml-language-model.c
+++ b/ggml-gobject/ggml-language-model.c
@@ -1517,8 +1517,7 @@ ggml_language_model_load_defined_from_istream_async (GGMLDefinedLanguageModel   
                                                      GGMLModelConfig           *model_config,
                                                      GCancellable              *cancellable,
                                                      GAsyncReadyCallback        callback,
-                                                     gpointer                   user_data,
-                                                     GError                   **error)
+                                                     gpointer                   user_data)
 {
   ggml_language_model_load_from_istream_async (istream,
                                                model_config,

--- a/ggml-gobject/ggml-language-model.c
+++ b/ggml-gobject/ggml-language-model.c
@@ -1315,7 +1315,7 @@ ggml_language_model_load_from_istream_on_token_dictionary_read (GObject *src,
 
   /* Continue reading the stream, now for the model itself.
    *
-   * After launching this, the model_forwad_func_user_data is transferred
+   * After launching this, the model_forward_func_user_data is transferred
    * to the subtask, so set to %NULL in the GGMLHyperparametersLoadFromIstreamData
    */
   ggml_model_load_from_istream_async (data->istream,

--- a/ggml-gobject/ggml-language-model.h
+++ b/ggml-gobject/ggml-language-model.h
@@ -39,6 +39,7 @@ GType ggml_language_model_completion_cursor_get_type (void);
 GGMLLanguageModelCompletionCursor * ggml_language_model_completion_cursor_ref (GGMLLanguageModelCompletionCursor *cursor);
 void ggml_language_model_completion_cursor_unref (GGMLLanguageModelCompletionCursor *cursor);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (GGMLLanguageModelCompletionCursor, ggml_language_model_completion_cursor_unref)
 
 typedef struct _GGMLLanguageModel GGMLLanguageModel;
 

--- a/ggml-gobject/ggml-language-model.h
+++ b/ggml-gobject/ggml-language-model.h
@@ -104,8 +104,7 @@ void ggml_language_model_load_defined_from_istream_async (GGMLDefinedLanguageMod
                                                           GGMLModelConfig           *model_config,
                                                           GCancellable              *cancellable,
                                                           GAsyncReadyCallback        callback,
-                                                          gpointer                   user_data,
-                                                          GError                   **error);
+                                                          gpointer                   user_data);
 GGMLLanguageModel *ggml_language_model_load_defined_from_istream_finish (GAsyncResult  *result,
                                                                          GError       **error);
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 # with ggml-gobject; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-project('ggml-gobject', ['c'],
+project('ggml-gobject', ['c', 'cpp'],
         version: '0.0.0',
         license: 'LGPL2+',
         meson_version: '>= 0.55.0')

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = googletest-1.13.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
+source_filename = gtest-1.13.0.tar.gz
+source_hash = ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363
+patch_filename = gtest_1.13.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.13.0-1/get_patch
+patch_hash = 6d82a02c3a45071cea989983bf6becde801cbbfd29196ba30dada0215393b082
+wrapdb_version = 1.13.0-1
+
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/tests/c/load_model.cpp
+++ b/tests/c/load_model.cpp
@@ -34,7 +34,7 @@ TEST(Tokenize, simple_string)
     NULL
   };
   g_autoptr(GGMLTokenDictionary) token_dictionary = ggml_token_dictionary_new (dictionary_strings);
-  int32_t *tokens_array;
+  g_autofree int32_t *tokens_array;
   size_t tokens_array_len;
 
   std::vector<int32_t> expected_tokens = {2, 0, 1, 0, 1};

--- a/tests/c/load_model.cpp
+++ b/tests/c/load_model.cpp
@@ -25,7 +25,7 @@
 
 #include <ggml-gobject/ggml-gobject.h>
 
-TEST(Tokenize, SimpleString)
+TEST(Tokenize, simple_string)
 {
   const char *dictionary_strings[] = {
     "ab",

--- a/tests/c/load_model.cpp
+++ b/tests/c/load_model.cpp
@@ -1,0 +1,50 @@
+/*
+ * tests/c/load_model.cpp
+ *
+ * Copyright (c) 2023 Sam Spilsbury
+ *
+ * ggml-gobject is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * ggml-gobject is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with ggml-gobject; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include <ggml-gobject/ggml-gobject.h>
+
+TEST(Tokenize, SimpleString)
+{
+  const char *dictionary_strings[] = {
+    "ab",
+    "bc",
+    "abbcd",
+    NULL
+  };
+  g_autoptr(GGMLTokenDictionary) token_dictionary = ggml_token_dictionary_new (dictionary_strings);
+  int32_t *tokens_array;
+  size_t tokens_array_len;
+
+  std::vector<int32_t> expected_tokens = {2, 0, 1, 0, 1};
+
+  EXPECT_TRUE (ggml_gpt_tokenize (token_dictionary,
+                                  "abbcdabbc ab de bc",
+                                  &tokens_array,
+                                  &tokens_array_len,
+                                  NULL));
+
+  std::vector<int32_t> tokens_vector (tokens_array, tokens_array + tokens_array_len);
+  EXPECT_EQ (tokens_vector, expected_tokens);
+}

--- a/tests/c/meson.build
+++ b/tests/c/meson.build
@@ -26,4 +26,4 @@ tests_exec = executable(
   ]
 )
 
-test('cpp-tests', tests_exec)
+test('cpp-tests', tests_exec, is_parallel: false)

--- a/tests/c/meson.build
+++ b/tests/c/meson.build
@@ -1,0 +1,29 @@
+gtest_proj = subproject('gtest')
+gtest_dep = gtest_proj.get_variable('gtest_dep')
+gmock_dep = gtest_proj.get_variable('gmock_dep')
+gmock_main_dep = gtest_proj.get_variable('gmock_main_dep')
+
+tests_src = files([
+  'load_model.cpp'
+])
+tests_exec = executable(
+  'cpp-tests',
+  tests_src,
+  dependencies : [
+    gtest_dep,
+    gmock_dep,
+    gmock_main_dep,
+    glib,
+    gio,
+    ggml,
+    soup
+  ],
+  link_with: [
+    ggml_gobject_lib
+  ],
+  include_directories : [
+    ggml_gobject_inc
+  ]
+)
+
+test('cpp-tests', tests_exec)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,1 +1,2 @@
 subdir('js')
+subdir('c')


### PR DESCRIPTION
A cursor represents the execution state of the model, including its memory. Execution from a cursor can
be resumed to get even more predictions. This is useful if the application depends on some user interaction to keep doing predictions in a certain way.

Also added some tests for the C API.